### PR TITLE
fix execution of provided scripts on Ubuntu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # See also: https://www.microsoft.com/net/core#linuxubuntu
 source /etc/os-release
 sudo apt update || exit

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 cd maci_backend
 screen -S backend -d -m bash -c "./run.sh"
 

--- a/stop.sh
+++ b/stop.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 screen -X -S backend quit
 screen -X -S jupyter quit
 


### PR DESCRIPTION
It seems if the scripts do no specify the /bin/bash shell interpreter,
some commands are not available, in particular the source one, making
the install.sh script breaking apt due to an invalid .list file.
Explicitly specifying the interpreter makes the script working.